### PR TITLE
Make sys/sysctl.h include be conditional. 

### DIFF
--- a/lib/irrlicht/source/Irrlicht/COSOperator.cpp
+++ b/lib/irrlicht/source/Irrlicht/COSOperator.cpp
@@ -17,7 +17,9 @@
 #ifdef ANDROID
 #include <linux/sysctl.h>
 #else
+#ifdef _IRR_OSX_PLATFORM_
 #include <sys/sysctl.h>
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
Fix build error on 21.04: fatal error: sys/sysctl.h: No such file or directory
From https://github.com/zaki/irrlicht/commit/d7c067cdef4e0753eed3177618ef308f2b71797c